### PR TITLE
Fix typo: "Smartip" => "Smartrip"

### DIFF
--- a/tests/selenium/transit_subsidy_ui_tests.py
+++ b/tests/selenium/transit_subsidy_ui_tests.py
@@ -150,7 +150,7 @@ def test_iterate_Smartrip_segments():
     def exercise_option(id):
         transit.add_segment( segment_id='1', mode_id=id, amount='1', add_another=False )
         transit.enroll()
-        is_textpresent(driver,'Enter your Smartip card number')
+        is_textpresent(driver,'Enter your Smartrip card number')
         
     for id in smartrips:
         transit.reset()

--- a/transit_subsidy/static/js/transit_subsidy.js
+++ b/transit_subsidy/static/js/transit_subsidy.js
@@ -35,7 +35,7 @@ $.validator.addMethod("smartrip_id", function(value, element) {
    if( value.length >= 9 ) return true;
    _retval = true;
 
-   //generate a list of Smartip ids
+   //generate a list of Smartrip ids
    var smartrips = $.map( segment_data, function(item){
      if (item['distribution_method'] == 'Smartrip') return item['id'];
    });
@@ -49,7 +49,7 @@ $.validator.addMethod("smartrip_id", function(value, element) {
       } 
    });
    return _retval;
- }, "Enter your Smartip card number.");
+ }, "Enter your Smartrip card number.");
 
 
 


### PR DESCRIPTION
More typos :)
